### PR TITLE
Adding Atomic Test for Finding and Accessing Unsecured Github Credent…

### DIFF
--- a/atomics/T1552.001/T1552.001.md
+++ b/atomics/T1552.001/T1552.001.md
@@ -16,6 +16,8 @@ In cloud and/or containerized environments, authenticated user and service accou
 
 - [Atomic Test #4 - Access unattend.xml](#atomic-test-4---access-unattendxml)
 
+- [Atomic Test #5 - Find and Access Github Credentials](#atomic-test-5---find-and-access-github-credentials)
+
 
 <br/>
 
@@ -113,6 +115,30 @@ If these files exist, their contents will be displayed. They are used to store c
 ```cmd
 type C:\Windows\Panther\unattend.xml
 type C:\Windows\Panther\Unattend\unattend.xml
+```
+
+
+
+
+
+
+<br/>
+<br/>
+
+## Atomic Test #5 - Find and Access Github Credentials
+This test looks for .netrc files (which stores github credentials in clear text )and dumps its contents if found.
+
+**Supported Platforms:** macOS, Linux
+
+
+
+
+
+#### Attack Commands: Run with `bash`! 
+
+
+```bash
+for file in $(find / -name .netrc 2> /dev/null);do echo $file ; cat $file ; done
 ```
 
 

--- a/atomics/T1552.001/T1552.001.yaml
+++ b/atomics/T1552.001/T1552.001.yaml
@@ -52,3 +52,17 @@ atomic_tests:
       type C:\Windows\Panther\Unattend\unattend.xml
     name: command_prompt
     elevation_required: true
+
+- name: Find and Access Github Credentials
+  description: |
+    This test looks for .netrc files (which stores github credentials in clear text )and dumps its contents if found.
+
+  supported_platforms:
+    - macos
+    - linux
+
+  executor:
+    name: bash
+    elevation_required: false # Indicates whether command must be run with admin privileges. If the elevation_required attribute is not defined, the value is assumed to be false.
+    command: | 
+      for file in $(find / -name .netrc 2> /dev/null);do echo $file ; cat $file ; done 


### PR DESCRIPTION
…ials along with Updated Markdown Version T1552.001.md

**Details:**
.netrc file stores clear text github credentials. While they are mostly stored in user's home directory , this tests looks for .netrc file for the entire filesystem. This means that if you have root privilege, it would look under every user's home directory for potential clear text github credentials.

**Testing:**
The testing was done manually ( locally ) on following OSes : Ubuntu , Kali , macOS mojave , macOS Big Sur

**Associated Issues:**
NA